### PR TITLE
adding a .timeout() static and a default timeout of 10s

### DIFF
--- a/lib/integration.js
+++ b/lib/integration.js
@@ -12,6 +12,7 @@ var errors = require('./errors');
 var proto = require('./proto');
 var assert = require('assert');
 var debug = require('debug');
+var ms = require('ms');
 
 /**
  * Expose `createIntegration`
@@ -59,10 +60,16 @@ function createIntegration(name){
   merge(Integration, statics);
 
   /**
-   * Enabeld on server
+   * Enabled on server
    */
 
   Integration.server();
+
+  /**
+   * Set a default timeout
+   */
+
+  Integration.timeout(ms('10s'));
 
   return Integration;
 };

--- a/lib/proto.js
+++ b/lib/proto.js
@@ -114,6 +114,7 @@ exports.request = function(method, path){
   var req = request[method](url);
   req.on('response', this.onresponse.bind(this));
   if (this.retries) req.retry(this.retries);
+  if (this.timeout) req.timeout(this.timeout);
   var end = req.end;
   req.end = onend;
   req.redirects(0);

--- a/lib/statics.js
+++ b/lib/statics.js
@@ -45,6 +45,19 @@ exports.mapper = function(mapper){
 };
 
 /**
+ * Set the timeout to `timeout`
+ *
+ * @param {Number} timeout in ms
+ * @return {Integration}
+ * @api public
+ */
+
+exports.timeout = function(timeout){
+  this.prototype.timeout = timeout;
+  return this;
+};
+
+/**
  * Enable this integration on `channel`.
  *
  * @param {String} channel

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "superagent": "~0.16.0",
     "slug-component": "~1.1.0",
     "superagent-retry": "~0.2.0",
-    "methods": "~0.1.0"
+    "methods": "~0.1.0",
+    "ms": "~0.6.2"
   },
   "devDependencies": {
     "mocha": "~1.17.1",


### PR DESCRIPTION
should help with our weird request times in prod

@yields @visionmedia 
