### PR TITLE
rename .events() -> .map()

### DIFF
--- a/lib/proto.js
+++ b/lib/proto.js
@@ -110,15 +110,15 @@ exports.enabled = function(facade, settings){
  * Examples:
  * 
  *    events = { my_event: 'a4991b88' }
- *    .events(events, 'My Event');
+ *    .map(events, 'My Event');
  *    // => ["a4991b88"]
- *    .events(events, 'whatever');
+ *    .map(events, 'whatever');
  *    // => []
  * 
  *    events = [{ key: 'my event', value: '9b5eb1fa' }]
- *    .events(events, 'my_event');
+ *    .map(events, 'my_event');
  *    // => ["9b5eb1fa"]
- *    .events(events, 'whatever');
+ *    .map(events, 'whatever');
  *    // => []
  * 
  * @param {Object} events
@@ -127,7 +127,7 @@ exports.enabled = function(facade, settings){
  * @api public
  */
 
-exports.events = function(events, str){
+exports.map = function(events, str){
   var a = normalize(str);
   var ret = [];
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "slug-component": "~1.1.0",
     "superagent-retry": "~0.2.0",
     "type": "git://github.com/segmentio/type",
-    "methods": "~0.1.0",
+    "methods": "0.0.1",
     "ms": "~0.6.2",
     "to-no-case": "^0.1.2",
     "uniq-component": "^1.0.0"

--- a/test/proto.js
+++ b/test/proto.js
@@ -17,48 +17,56 @@ describe('proto', function(){
       .mapper({})();
   })
 
-  describe('#events', function(){
-    describe('when options.events is an object', function(){
+  describe('#map', function(){
+    describe('when `map` is not an object or array', function(){
+      it('should return an empty array', function(){
+        assert.deepEqual([], segment.map(0, ''));
+        assert.deepEqual([], segment.map('', ''));
+        assert.deepEqual([], segment.map(null, ''));
+        assert.deepEqual([], segment.map(Number, ''));
+      })
+    })
+    describe('when `map` is an object', function(){
       it('should return an empty array on mismatch', function(){
-        var events = { a: '4be41523', b: 'd49ccea' };
-        assert.deepEqual([], segment.events(events, 'c'));
+        var map = { a: '4be41523', b: 'd49ccea' };
+        assert.deepEqual([], segment.map(map, 'c'));
       })
 
       it('should return an array with the value on match', function(){
-        var events = { a: '48dc32b2', b: '48dc32b2' };
-        assert.deepEqual(['48dc32b2'], segment.events(events, 'b'));
+        var map = { a: '48dc32b2', b: '48dc32b2' };
+        assert.deepEqual(['48dc32b2'], segment.map(map, 'b'));
       })
 
       it('should use to-no-case to match keys', function(){
-        var events = { 'My Event': '7b4fe803', 'other event': '2107007a' };
-        assert.deepEqual(['7b4fe803'], segment.events(events, 'my_event'));
+        var map = { 'My Event': '7b4fe803', 'other event': '2107007a' };
+        assert.deepEqual(['7b4fe803'], segment.map(map, 'my_event'));
       })
     })
 
     describe('when .options.events is an array', function(){
       it('should return an empty array if the array isnt a map', function(){
-        var events = ['one', 'two'];
-        assert.deepEqual([], segment.events(events, 'one'));
+        var map = ['one', 'two'];
+        assert.deepEqual([], segment.map(map, 'one'));
       })
 
       it('should return an empty array when the array is empty', function(){
-        var events = [];
-        assert.deepEqual([], segment.events(events, 'wee'));
+        var map = [];
+        assert.deepEqual([], segment.map(map, 'wee'));
       })
 
       it('should return an empty array on mismatch', function(){
-        var events = [{ key: 'my event', value: '1121f10f' }];
-        assert.deepEqual([], segment.events(events, 'event'));
+        var map = [{ key: 'my event', value: '1121f10f' }];
+        assert.deepEqual([], segment.map(map, 'event'));
       })
 
       it('should return all matches in the array', function(){
-        var events = [{ key: 'baz', value: '4cff6219' }, { key: 'baz', value: '4426d54'} ];
-        assert.deepEqual(['4cff6219', '4426d54'], segment.events(events, 'baz'));
+        var map = [{ key: 'baz', value: '4cff6219' }, { key: 'baz', value: '4426d54'} ];
+        assert.deepEqual(['4cff6219', '4426d54'], segment.map(map, 'baz'));
       })
 
       it('should use to-no-case to match keys', function(){
-        var events = [{ key: 'My Event', value: 'a35bd696' }];
-        assert.deepEqual(['a35bd696'], segment.events(events, 'my_event'));
+        var map = [{ key: 'My Event', value: 'a35bd696' }];
+        assert.deepEqual(['a35bd696'], segment.map(map, 'my_event'));
       })
     })
   })


### PR DESCRIPTION
- rename `.events()` -> `.map()` to match analytics.js-integration
- depend on methods@0.0.1 like superagent.
- add more tests to the new `.map()`.

cc @calvinfo 
