### PR TITLE
mapper: fix context

### DIFF
--- a/lib/wrap-methods.js
+++ b/lib/wrap-methods.js
@@ -36,7 +36,7 @@ module.exports = function(integration){
     if (!mapper[method]) return;
     var fn = integration[method];
     integration[method] = function(message, settings, callback){
-      var payload = mapper[method](message, settings);
+      var payload = mapper[method].call(this, message, settings);
       this.debug('mapped %j to %j', message, payload);
       return fn.call(this, payload, settings, callback);
     };

--- a/test/proto.js
+++ b/test/proto.js
@@ -241,6 +241,20 @@ describe('proto', function(){
       test.prototype.identify = mapper.test(done);
       test().identify({}, {}, done);
     })
+
+    it('should call the mapper with the correct context', function(){
+      var Test = integration('test').mapper({ track: track });
+      Test.prototype.track = function(){};
+      var test = Test();
+      test.track(helpers.track());
+      var ctx;
+
+      function track(){
+        ctx = this;
+      }
+
+      assert(ctx == test);
+    });
   })
 
   describe('.track(track, settings, fn)', function(){


### PR DESCRIPTION
fixes context, some integrations depend on `this.name` :/

@calvinfo 
