### PR TITLE
normalize errors and add .error(msg, ...) as BadRequest

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -4,23 +4,15 @@
  */
 
 var inherits = require('util').inherits;
+var fmt = require('util').format;
 
 /**
  * Expose errors.
  */
 
-exports.Validation = IntegrationValidationError;
-exports.BadRequest = BadRequestError;
-
-/**
- * Expose error types.
- */
-
-exports.types = {
-  'validation': IntegrationValidationError,
-  'bad-request': BadRequestError,
-  'reject': MessageRejectedError
-};
+exports.ValidationError = IntegrationValidationError;
+exports.RejectedError = MessageRejectedError;
+exports.BadRequestError = BadRequestError;
 
 /**
  * Validation error, when a setting is missing or of the incorrect type.
@@ -30,12 +22,11 @@ exports.types = {
  * @param {Object} ctx
  */
 
-function IntegrationValidationError(message, integration, ctx){
+function IntegrationValidationError(message, integration){
   Error.captureStackTrace(this, IntegrationValidationError);
   Error.call(this);
   this.integration = integration;
-  this.message = message;
-  this.settings = ctx;
+  this.message = fmt('%s: %s', integration, message);
   this.code = 'INVALID_SETTINGS';
 }
 
@@ -51,7 +42,7 @@ function BadRequestError(message, integration, ctx) {
   Error.captureStackTrace(this, BadRequestError);
   Error.call(this);
   var ctx = ctx || {};
-  this.message = message;
+  this.message = fmt('%s: %s', integration, message);
   this.integration = integration;
   this.status = ctx.status;
   this.body = ctx.body;
@@ -68,7 +59,7 @@ function BadRequestError(message, integration, ctx) {
 function MessageRejectedError(message, integration){
   Error.captureStackTrace(this, MessageRejectedError);
   Error.call(this);
-  this.message = message;
+  this.message = fmt('%s: %s', integration, message);
   this.integration = integration;
   this.code = 'MESSAGE_REJECTED';
 }

--- a/lib/integration.js
+++ b/lib/integration.js
@@ -78,22 +78,20 @@ function createIntegration(name){
   Integration.server();
 
   /**
-   * Create error of `type` with `msg` and `ctx`.
+   * Create error with `msg`.
    *
-   * @param {String} type
    * @param {String} msg
-   * @param {Object} ctx
+   * @param {...} args
    * @return {Error}
    * @api public
    */
 
   Integration.error =
-  Integration.prototype.error = function(type, msg, ctx){
-    var Type = errors.types[type];
-    assert(Type, '"' + type + '" error was not found');
-    var err = new Type(name + ': ' + msg, name, ctx);
-    err.ctx = ctx;
-    return err;
+  Integration.prototype.error = function(){
+    var msg = fmt.apply(null, arguments);
+    // TODO: cache and add .request and .response to ctx.
+    var ctx = {};
+    return new errors.BadRequestError(msg, name, ctx);
   };
 
   /**
@@ -107,7 +105,8 @@ function createIntegration(name){
 
   Integration.invalid =
   Integration.prototype.invalid = function(){
-    return this.error('validation', fmt.apply(null, arguments));
+    var msg = fmt.apply(null, arguments);
+    return new errors.ValidationError(msg, name);
   };
 
   /**
@@ -121,7 +120,8 @@ function createIntegration(name){
 
   Integration.reject =
   Integration.prototype.reject = function(){
-    return this.error('reject', fmt.apply(null, arguments));
+    var msg = fmt.apply(null, arguments);
+    return new errors.RejectedError(msg, name);
   };
 
   /**

--- a/test/errors.js
+++ b/test/errors.js
@@ -1,6 +1,6 @@
 
-var ValidationError = require('../lib/errors').Validation;
-var BadRequest = require('../lib/errors').BadRequest;
+var ValidationError = require('../lib/errors').ValidationError;
+var BadRequest = require('../lib/errors').BadRequestError;
 var integration = require('..');
 var assert = require('assert');
 
@@ -8,7 +8,7 @@ describe('errors', function(){
   describe('BadRequest', function(){
     it('should expose .stack', function(){
       var err = new BadRequest('error', 'Segment', { status: 400, body: 'body' });
-      assert.equal('error', err.message);
+      assert.equal('Segment: error', err.message);
       assert.equal('BAD_REQUEST', err.code);
       assert.equal('Segment', err.integration);
       assert.equal(400, err.status);
@@ -23,30 +23,34 @@ describe('errors', function(){
 
   describe('ValidationError', function(){
     it('should expose .stack', function(){
-      var err = new ValidationError('.key is required');
+      var err = new ValidationError('.key is required', 'Segment');
       assert.equal('INVALID_SETTINGS', err.code);
-      assert.equal('.key is required', err.message);
+      assert.equal('Segment: .key is required', err.message);
     });
   });
 
-  describe('.error("validation", msg, ctx)', function(){
-    it('should return new validation error', function(){
+  describe('.error(msg)', function(){
+    it('should return new bad request error', function(){
       var Segment = integration('Segment');
-      var err = Segment.error('validation', 'message', {});
-      assert.equal('INVALID_SETTINGS', err.code);
+      var err = Segment.error('message');
+      assert.equal('BAD_REQUEST', err.code);
       assert.equal('Segment: message', err.message);
       assert.equal('Segment', err.integration);
-      assert.deepEqual({}, err.ctx);
     });
   });
 
-  describe('.error("bad-request", msg, ctx)', function(){
+  describe('.error(msg)', function(){
     var Segment = integration('Segment');
-    var ctx = { status: 400, body: 'bad input' };
-    var err = Segment.error('bad-request', 'message', ctx);
+    var err = Segment.error('message');
     assert.equal('BAD_REQUEST', err.code);
     assert.equal('Segment: message', err.message);
     assert.equal('Segment', err.integration);
-    assert.deepEqual(err.ctx, ctx);
+  });
+
+  describe('.invalid(msg)', function(){
+    it('should return invalid settings error', function(){
+      var Segment = integration('Segment');
+      var err = Segment.invalid('error');
+    });
   });
 });


### PR DESCRIPTION
this adds `.error(msg, ...)`, i removed the previous `.error(msg, ctx{ status, body})` because i think upstream should be intelligent enough to capture `res.text` etc..

for integrations that do multiple requests, we can always have the proto cache the current `req` instance somewhere and use it in `.error()` call itself.

``` js
identfy = function(msg, fn){
  fn(self.error('something blew up %s', hint));
};
```

cc @gjohnson
