### PR TITLE
lowering locking retry

### DIFF
--- a/lib/proto.js
+++ b/lib/proto.js
@@ -170,7 +170,7 @@ exports.map = function(events, str){
 
 exports.lock = function(key, fn){
   var key = [this.name, key].join(':');
-  var lock = Lock({ key: key, redis: this.redis() });
+  var lock = Lock({ key: key, redis: this.redis(), retry: 100 });
   var emit = this.emit.bind(this);
   lock.lock(function(err){
     if (err) emit('lock error', err, lock);


### PR DESCRIPTION
Lowering the lock retry so that integrations will retry
a bit closer to the standard response time

@gjohnson 
