### PR TITLE
Remove nextTick

### DIFF
--- a/lib/proto.js
+++ b/lib/proto.js
@@ -395,7 +395,7 @@ methods.forEach(function(method){
 function tick(name){
   return function(_, fn){
     this.debug('%s is not implemented', name);
-    process.nextTick(fn);
+    setImmediate(fn);
   };
 }
 


### PR DESCRIPTION
Prefer `setImmediate` over `process.nextTick`\- My testing shows that when large amounts of the [stubbed](https://github.com/segmentio/integration/blob/master/lib/proto.js#L65) out methods run that are backed by [tick](https://github.com/segmentio/integration/blob/master/lib/proto.js#L395-L400), they drown out all the I/O since `process.nextTick` runs before any I/O.
