### PR TITLE
Refactor retries

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -269,14 +269,18 @@ MyIntegration.prototype.track = function(msg, fn){
   By default it checks for:
  
   ```js
+  err.status = 500
   err.status = 502
   err.status = 503
   err.status = 504
   err.code = "ETIMEDOUT"
   err.code = "EADDRINFO"
+  err.code = "EADDRINFO"
   err.code = "ECONNRESET"
-  err.code = "ESOCKETTIMEDOUT"
-  err.timeout = N
+  err.code = "ECONNREFUSED"
+  err.code = "ECONNABORTED"
+  err.code = "EHOSTUNREACH"
+  err.code = "ENOTFOUND"
   ```
  
   When the method returns true the worker re-queues the message

--- a/lib/proto.js
+++ b/lib/proto.js
@@ -6,6 +6,7 @@
 var ValidationError = require('./errors').Validation;
 var normalize = require('to-no-case');
 var request = require('superagent');
+var retries = require('./retries');
 var Lock = require('shared-lock');
 var fmt = require('util').format;
 var methods = require('methods');
@@ -201,22 +202,38 @@ exports.request = function(method, path){
   method = method || 'get';
   var url = path || '';
   var self = this;
+
   if (!isAbsolute(url)) url = this.endpoint + url;
   this.debug('create request %s', method, url);
-  var req = request[method](url);
-  req.set('User-Agent', 'Segment.io/1.0');
-  req.on('response', this.onresponse.bind(this));
-  if (this.timeout) req.timeout(this.timeout);
-  var end = req.end;
-  req.end = onend;
-  req.redirects(0);
-  return req;
 
-  function onend(){
+  var req = request[method](url);
+  var end = req.end;
+
+  req.on('response', this.onresponse.bind(this));
+  req.set('User-Agent', 'Segment.io/1.0');
+  req.redirects(0);
+  req.end = onend;
+
+  if (this.timeout) req.timeout(this.timeout);
+
+  function onend(fn){
+    fn = fn || noop;
     self.emit('request', this);
     self.debug('request %s %j', req.url, req._data);
-    return end.apply(this, arguments);
+    end.call(this, function(err, res){
+      if (err) return onerror(err, res, fn);
+      if (res.error) return onerror(res.error, res, fn);
+      return fn(null, res);
+    });
+    return req;
   }
+
+  function onerror(err, res, fn){
+    if (err.timeout) err.code = 'ECONNABORTED';
+    return fn(err, res);
+  }
+
+  return req;
 };
 
 /**
@@ -314,23 +331,12 @@ exports.onresponse = function(res){
 };
 
 /**
- * Retry?
+ * Determine if the `err` is retriable.
  *
  * This method gets invoked by the worker
  * after the worker recieves an `(err,)`, it
  * will call this method to figure out if this integration
  * needs to retry this request.
- *
- * By default it checks for:
- *
- *  - `.status=502`
- *  - `.status=503`
- *  - `.status=504`
- *  - `.code=ETIMEDOUT`
- *  - `.code=EADDRINFO`
- *  - `.code=ECONNRESET`
- *  - `.code=ESOCKETTIMEDOUT`
- *  - `.timeout=N` (superagent's timeout)
  *
  * You can "extend" this method easily like:
  *
@@ -346,12 +352,9 @@ exports.onresponse = function(res){
  */
 
 exports.retry = function(err){
-  return !!~[502,503,504].indexOf(err.status)
-    || err.code == 'ETIMEDOUT'
-    || err.code == 'EADDRINFO'
-    || err.code == 'ECONNRESET'
-    || err.code == 'ESOCKETTIMEDOUT'
-    || !!err.timeout;
+  return err && retries.some(function(fn){
+    return fn(err);
+  });
 };
 
 /**
@@ -360,10 +363,12 @@ exports.retry = function(err){
  * @param {Function} fn
  * @return {Function}
  * @api private
+ * @deprecated
  */
 
 exports.handle = function(fn){
   return function(err, res){
+    this.debug('.handle is deprecated');
     if (err) return fn(err, res);
     if (res.error) return fn(res.error, res);
     fn(null, res);

--- a/lib/retries.js
+++ b/lib/retries.js
@@ -1,0 +1,46 @@
+
+/**
+ * Retriable.
+ *
+ * @api private
+ */
+
+module.exports = [
+  status,
+  network
+];
+
+/**
+ * Retry common status err.codes that are a result
+ * of server issues or rate limits. Way too hard
+ * to catch everything here, but these catch most.
+ *
+ * @param {String|Number} err.code
+ * @return {Boolean}
+ * @api private
+ */
+
+function status(err){
+  return err.status == 500
+    || err.status == 502
+    || err.status == 503
+    || err.status == 504;
+}
+
+/**
+ * Retry common network issues.
+ *
+ * @param {String} err.code
+ * @return {Boolean}
+ * @api private
+ */
+
+function network(err){
+  return err.code == 'ECONNRESET'
+    || err.code == 'ECONNREFUSED'
+    || err.code == 'ECONNABORTED'
+    || err.code == 'ETIMEDOUT'
+    || err.code == 'EADDRINFO'
+    || err.code == 'EHOSTUNREACH'
+    || err.code == 'ENOTFOUND';
+}

--- a/test/proto.js
+++ b/test/proto.js
@@ -528,6 +528,10 @@ describe('proto', function(){
   })
 
   describe('.retry(err)', function(){
+    it('500', function(){
+      assert(true == segment.retry({ status: 500 }));
+    });
+
     it('502', function(){
       assert(true == segment.retry({ status: 502 }));
     });
@@ -540,6 +544,18 @@ describe('proto', function(){
       assert(true == segment.retry({ status: 504 }));
     });
 
+    it('ECONNRESET', function(){
+      assert(true == segment.retry({ code: 'ECONNRESET' }));
+    });
+
+    it('ECONNREFUSED', function(){
+      assert(true == segment.retry({ code: 'ECONNREFUSED' }));
+    });
+
+    it('ECONNABORTED', function(){
+      assert(true == segment.retry({ code: 'ECONNABORTED' }));
+    });
+
     it('ETIMEDOUT', function(){
       assert(true == segment.retry({ code: 'ETIMEDOUT' }));
     });
@@ -548,18 +564,9 @@ describe('proto', function(){
       assert(true == segment.retry({ code: 'EADDRINFO' }));
     });
 
-    it('ECONNRESET', function(){
-      assert(true == segment.retry({ code: 'ECONNRESET' }));
+    it('ENOTFOUND', function(){
+      assert(true == segment.retry({ code: 'ENOTFOUND' }));
     });
-
-    it('ESOCKETTIMEDOUT', function(){
-      assert(true == segment.retry({ code: 'ESOCKETTIMEDOUT' }));
-    });
-
-    it('.timeout', function(){
-      assert(true == segment.retry({ timeout: 3000 }));
-      assert(true == segment.retry({ timeout: 2000 }));
-    })
 
     it('should not error on other errors', function(){
       assert(false == segment.retry({}));


### PR DESCRIPTION
- Tweaked the `.request` method a bit so I could wrap the callback passed to `req.end`. This is so I could patch an error code for timeouts so that we stop relying on superagent specific error stuff. As a side effect, I think `.handle` is no longer needed since I didn't put the error wrapping in there so we'd have the same `err, res` semantics everywhere (even if an integration forgot to use `.handle`).
- Moved the retries stuff into a little module.
- Added a couple new codes based on some log data.

cc: @yields 
