### PR TITLE
Remove default implementations

### DIFF
--- a/lib/proto.js
+++ b/lib/proto.js
@@ -29,7 +29,7 @@ exports.initialize = function(){};
  * @api public
  */
 
-exports.identify = tick('identify');
+exports.identify;
 
 /**
  * Track.
@@ -40,7 +40,7 @@ exports.identify = tick('identify');
  * @api public
  */
 
-exports.track = tick('track');
+exports.track;
 
 /**
  * Alias.
@@ -51,7 +51,7 @@ exports.track = tick('track');
  * @api public
  */
 
-exports.alias = tick('alias');
+exports.alias;
 
 /**
  * Group.
@@ -62,7 +62,7 @@ exports.alias = tick('alias');
  * @api public
  */
 
-exports.group = tick('group');
+exports.group;
 
 /**
  * Page.
@@ -73,7 +73,7 @@ exports.group = tick('group');
  * @api public
  */
 
-exports.page = tick('page');
+exports.page;
 
 /**
  * Screen.
@@ -84,7 +84,7 @@ exports.page = tick('page');
  * @api public
  */
 
-exports.screen = tick('screen');
+exports.screen;
 
 /**
  * Enabled.
@@ -384,20 +384,6 @@ methods.forEach(function(method){
     return this.request(method, path);
   };
 });
-
-/**
- * Tick.
- *
- * @return {Function}
- * @api private
- */
-
-function tick(name){
-  return function(_, fn){
-    this.debug('%s is not implemented', name);
-    setImmediate(fn);
-  };
-}
 
 /**
  * Is absolute.

--- a/test/proto.js
+++ b/test/proto.js
@@ -253,10 +253,6 @@ describe('proto', function(){
   })
 
   describe('.identify(identify, fn)', function(){
-    it('should do nothing', function(done){
-      segment.identify({}, done);
-    })
-
     it('should map identify if mapper.identify is defined', function(done){
       var test = integration('test').mapper({ identify: mapper() });
       test.prototype.identify = mapper.test(done);
@@ -279,11 +275,6 @@ describe('proto', function(){
   })
 
   describe('.track(track, fn)', function(){
-    it('should do nothing', function(done){
-      var msg = helpers.track();
-      segment.track(msg, done);
-    })
-
     it('should map track if mapper.track is defined', function(done){
       var test = integration('test').mapper({ track: mapper() });
       test.prototype.track = mapper.test(done);
@@ -427,10 +418,6 @@ describe('proto', function(){
       test().page({}, done);
     })
 
-    it('should do nothing by default', function(done){
-      integration('test')().page(null, done);
-    });
-
     it('should send "Loaded a Page" if .trackAllPages is true', function(done){
       segment.settings.trackAllPages = true;
       segment.page(page, function(err){
@@ -504,10 +491,6 @@ describe('proto', function(){
   })
 
   describe('.screen(screen, fn)', function(){
-    it('should do nothing', function(done){
-      segment.screen({}, done);
-    })
-
     it('should map screen if mapper.screen is defined', function(done){
       var test = integration('test').mapper({ screen: mapper() });
       test.prototype.screen = mapper.test(done);
@@ -516,10 +499,6 @@ describe('proto', function(){
   })
 
   describe('.group(group, fn)', function(){
-    it('should do nothing', function(done){
-      segment.group({}, done);
-    })
-
     it('should map group if mapper.group is defined', function(done){
       var test = integration('test').mapper({ group: mapper() });
       test.prototype.group = mapper.test(done);


### PR DESCRIPTION
Really no reason to go through validations, ensuring, etc. for a method that isn't even implemented on an integration.
