### PR TITLE
Dont return request instance to caller

### DIFF
--- a/lib/proto.js
+++ b/lib/proto.js
@@ -231,12 +231,11 @@ exports.request = function(method, path){
     fn = fn || noop;
     self.emit('request', this);
     self.debug('request %s %j', req.url, req._data);
-    end.call(this, function(err, res){
+    return end.call(this, function(err, res){
       if (err) return onerror(err, res, fn);
       if (res.error) return onerror(res.error, res, fn);
       return fn(null, res);
     });
-    return req;
   }
 
   function onerror(err, res, fn){


### PR DESCRIPTION
Fixes an internal memory leak we are having.
