### PR TITLE
Provide more helpful error messages.

### DIFF
--- a/lib/proto.js
+++ b/lib/proto.js
@@ -12,6 +12,7 @@ var fmt = require('util').format;
 var methods = require('methods');
 var Batch = require('batch');
 var type = require('type');
+var status = require('statuses');
 
 /**
  * Retry checks.
@@ -240,6 +241,9 @@ exports.request = function(method, path){
 
   function onerror(err, res, fn){
     if (err.timeout) err.code = 'ECONNABORTED';
+    // Superagent's default messages are very generic, try to provide
+    // something more helpful.
+    err.message = status[err.status] || err.message;
     return fn(err, res);
   }
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "superagent": "^0.21.0",
     "to-no-case": "^0.1.2",
     "type": "git://github.com/segmentio/type",
-    "uniq-component": "^1.0.0"
+    "uniq-component": "^1.0.0",
+    "statuses": "^1.2.1"
   },
   "devDependencies": {
     "batch": "^0.5.1",


### PR DESCRIPTION
Instead of something generic like `cannot POST /in.php (404)`; show a
user friendly text message like `Not Found`
