### PR TITLE
map screen to page and vice-versa

### DIFF
--- a/lib/wrap-methods.js
+++ b/lib/wrap-methods.js
@@ -21,8 +21,9 @@ var methods = [
 /**
  * Wrap methods of `integration`.
  *
- *    - uses `mapper` if possible
+ *    - uses `mapper` if possible.
  *    - routes all ecommerce events to other methods if possible.
+ *    - maps page to screen or vice-versa if only one is provided.
  *
  * @param {Integration} integration
  * @api private
@@ -30,6 +31,17 @@ var methods = [
 
 module.exports = function(integration){
   var mapper = integration.mapper || {};
+
+  if (mapper.page && !mapper.screen) {
+    mapper.screen = mapper.page;
+  } else if (mapper.screen && !mapper.page) {
+    mapper.page = mapper.screen;
+  }
+  if (integration.page && !integration.screen) {
+    integration.screen = integration.page;
+  } else if (integration.screen && !integration.page) {
+    integration.page = integration.screen;
+  }
 
   // use mapper.
   methods.forEach(function(method){

--- a/test/proto.js
+++ b/test/proto.js
@@ -452,6 +452,12 @@ describe('proto', function(){
       test().page({}, done);
     });
 
+    it('should map page if mapper.screen is defined', function(done){
+      var test = integration('test').mapper({ screen: mapper() });
+      test.prototype.page = mapper.test(done);
+      test().page({}, done);
+    });
+
     it('should send "Loaded a Page" if .trackAllPages is true', function(done){
       segment.settings.trackAllPages = true;
       segment.page(page, function(err){
@@ -522,6 +528,20 @@ describe('proto', function(){
         done();
       });
     });
+
+    it('should send events for screen when only page is defined', function(done){
+      segment.settings.trackAllPages = true;
+      segment.settings.trackNamedPages = true;
+      segment.settings.trackCategorizedPages = true;
+      segment.screen(page, function(err){
+        if (err) return done(err);
+        assert.equal(tracks.length, 3);
+        assert.equal(tracks[0].event(), 'Loaded a Page');
+        assert.equal(tracks[1].event(), 'Viewed Docs Page');
+        assert.equal(tracks[2].event(), 'Viewed Docs Integration Page');
+        done();
+      });
+    });
   });
 
   describe('.screen(screen, fn)', function(){
@@ -556,6 +576,12 @@ describe('proto', function(){
 
     it('should map screen if mapper.screen is defined', function(done){
       var test = integration('test').mapper({ screen: mapper() });
+      test.prototype.screen = mapper.test(done);
+      test().screen({}, done);
+    });
+
+    it('should map screen if mapper.page is defined', function(done){
+      var test = integration('test').mapper({ page: mapper() });
       test.prototype.screen = mapper.test(done);
       test().screen({}, done);
     });
@@ -630,7 +656,22 @@ describe('proto', function(){
         done();
       });
     });
+
+    it('should send events for page when only screen is defined', function(done){
+      segment.settings.trackAllPages = true;
+      segment.settings.trackNamedPages = true;
+      segment.settings.trackCategorizedPages = true;
+      segment.page(screen, function(err){
+        if (err) return done(err);
+        assert.equal(tracks.length, 3);
+        assert.equal(tracks[0].event(), 'Loaded a Screen');
+        assert.equal(tracks[1].event(), 'Viewed Docs Screen');
+        assert.equal(tracks[2].event(), 'Viewed Docs Integration Screen');
+        done();
+      });
+    });
   });
+
   describe('.group(group, fn)', function(){
     it('should map group if mapper.group is defined', function(done){
       var test = integration('test').mapper({ group: mapper() });


### PR DESCRIPTION
Most tools don't distinguish between screen and page, and treat them interchangeably. A [quick
search](https://github.com/search?l=javascript&p=3&q=user%3Asegmentio+screen+page+integration&ref=searchresults&type=Code&utf8=%E2%9C%93) validates this hypothesis. GA and Calq are examples of integration that treat them slightly differently.

This is important since this enables web (page) focussed tools to work with mobile (screen) focussed tools without explicitly opting into this behaviour (and it's the right behaviour 90% of the time so far).

Integrations can still opt to declare both functions separately if they want (such as GA and Calq).