### PR TITLE
Make sure `fn` si defined when handling response

### DIFF
--- a/lib/proto.js
+++ b/lib/proto.js
@@ -352,6 +352,7 @@ exports.onresponse = function(res){
  */
 
 exports.handle = function(fn){
+  fn = fn || noop;
   return function(err, res){
     if (err) return fn(err, res);
     fn(null, res);


### PR DESCRIPTION
We need to make sure `fn` si defined when handling response before using it. Not sure if this is the right behavior but if fixes an issue I had using the MailChimp integration.