### PR TITLE
Server side debugger dep

### DIFF
--- a/lib/proto.js
+++ b/lib/proto.js
@@ -234,7 +234,7 @@ exports.request = function(method, path){
     return end.call(this, function(err, res){
       if (err) return onerror(err, res, fn);
       if (res.error) return onerror(res.error, res, fn);
-      return fn(null, res);
+      return fn(null, {response: res, request: req});
     });
   }
 

--- a/lib/proto.js
+++ b/lib/proto.js
@@ -234,7 +234,8 @@ exports.request = function(method, path){
     return end.call(this, function(err, res){
       if (err) return onerror(err, res, fn);
       if (res.error) return onerror(res.error, res, fn);
-      return fn(null, { response: res, request: req });
+      res.req = req;
+      return fn(null, res);
     });
   }
 

--- a/lib/proto.js
+++ b/lib/proto.js
@@ -234,7 +234,7 @@ exports.request = function(method, path){
     return end.call(this, function(err, res){
       if (err) return onerror(err, res, fn);
       if (res.error) return onerror(res.error, res, fn);
-      return fn(null, {response: res, request: req});
+      return fn(null, { response: res, request: req });
     });
   }
 


### PR DESCRIPTION
Changed the "request" method to attach the http request (that gets sent to our downsteam integrations) to the response object - such that the request will be returned to the client's callback if they pass a callback to any of our server-side library methods. 