### PR TITLE
adding ability to set ca

### DIFF
--- a/lib/proto.js
+++ b/lib/proto.js
@@ -219,6 +219,7 @@ exports.request = function(method, path){
   var req = request[method](url);
   var end = req.end;
 
+  if (this.ca) req.ca(this.ca);
   if (this.agent) req.agent(this.agent);
   if (this.timeout) req.timeout(this.timeout);
 

--- a/lib/statics.js
+++ b/lib/statics.js
@@ -216,6 +216,20 @@ exports.agent = function(agent){
 };
 
 /**
+ * Sets the list of cas to use for all https
+ * requests.
+ *
+ * @param {Buffer | Array} cert
+ * @return {Request} for chaining
+ * @api public
+ */
+
+exports.ca = function(ca){
+  this.prototype.ca = ca;
+  return this;
+};
+
+/**
  * Enable this integration on `channel`.
  *
  * TODO: deprecate

--- a/test/statics.js
+++ b/test/statics.js
@@ -140,4 +140,13 @@ describe('statics', function(){
       assert.equal('my-testio', test.slug());
     });
   });
+
+  describe('#ca', function(){
+    it('should allow you to set the list of cs', function(){
+      var test = integration('test');
+      test.ca(['foo']);
+      var req = test().request();
+      assert.deepEqual(req._ca, ['foo']);
+    })
+  })
 })


### PR DESCRIPTION
This commit adds the ability to set just the CA list, so we don't have to worry about the agent

@yields @f2prateek 