### PR TITLE
Retry all non-HTTP errors

### DIFF
--- a/lib/retries.js
+++ b/lib/retries.js
@@ -6,55 +6,47 @@
  */
 
 module.exports = [
-  status,
-  network,
-  locked
+  nonHttp,
+  httpServer,
+  httpClient
 ];
 
 /**
- * Retry common status err.codes that are a result
- * of server issues or rate limits. Way too hard
- * to catch everything here, but these catch most.
+ * Retry non HTTP errors.
+ *
+ * @param {String|Number} err.code
+ * @return {Boolean}
+ * @api private
+ */
+function nonHttp(err){
+  return err.status ? false : true;
+}
+
+/**
+ * Retry common http status codes that are a result
+ * of server issues.
  *
  * @param {String|Number} err.code
  * @return {Boolean}
  * @api private
  */
 
-function status(err){
+function httpServer(err){
   return err.status == 500
     || err.status == 502
     || err.status == 503
-    || err.status == 504
-    || err.status == 429;
+    || err.status == 504;
 }
 
 /**
- * Retry common network issues.
+ * Retry common http status codes that are a result
+ * of client issues such as rate limits.
  *
- * @param {String} err.code
+ * @param {String|Number} err.code
  * @return {Boolean}
  * @api private
  */
 
-function network(err){
-  return err.code == 'ECONNRESET'
-    || err.code == 'ECONNREFUSED'
-    || err.code == 'ECONNABORTED'
-    || err.code == 'ETIMEDOUT'
-    || err.code == 'EADDRINFO'
-    || err.code == 'EHOSTUNREACH'
-    || err.code == 'ENOTFOUND';
-}
-
-/**
- * Resource locks.
- *
- * @param {Error} err
- * @return {Boolean}
- * @api private
- */
-
-function locked(err){
-  return err.code == 'RESOURCE_LOCKED';
+function httpClient(err){
+  return err.status == 429;
 }

--- a/test/proto.js
+++ b/test/proto.js
@@ -685,8 +685,24 @@ describe('proto', function(){
   });
 
   describe('.retry(err)', function(){
+    it('200', function(){
+      assert(false == segment.retry({ status: 200 }));
+    });
+
+    it('404', function(){
+      assert(false == segment.retry({ status: 404 }));
+    });
+
+    it('429', function(){
+      assert(true == segment.retry({ status: 429 }));
+    });
+
     it('500', function(){
       assert(true == segment.retry({ status: 500 }));
+    });
+
+    it('501', function(){
+      assert(false == segment.retry({ status: 501 }));
     });
 
     it('502', function(){
@@ -699,10 +715,6 @@ describe('proto', function(){
 
     it('504', function(){
       assert(true == segment.retry({ status: 504 }));
-    });
-
-    it('429', function(){
-      assert(true == segment.retry({ status: 429 }));
     });
 
     it('ECONNRESET', function(){
@@ -729,10 +741,10 @@ describe('proto', function(){
       assert(true == segment.retry({ code: 'ENOTFOUND' }));
     });
 
-    it('should not error on other errors', function(){
-      assert(false == segment.retry({}));
-      assert(false == segment.retry(new Error('whoops')));
-      assert(false == segment.retry(new TypeError('whoops')));
+    it('should error on other errors', function(){
+      assert(true == segment.retry({}));
+      assert(true == segment.retry(new Error('whoops')));
+      assert(true == segment.retry(new TypeError('whoops')));
     });
   });
 


### PR DESCRIPTION
Intstead of whitelisting specific errors to retry, which is not an
exhaustive list (e.g. untrusted certificater errors), we now retry
for:

1. any non HTTP error (i.e. a connection wasn't even made)
2. Any server http errors, which includes, 500, 502, 503 and 504.
3. Any client http errors, includes 429.