### PR TITLE
Update superagent to 2.x to fix uncaught TypeError bug

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ test: node_modules lint
 	@$(MOCHA) \
 		--reporter spec \
 		--inline-diffs \
-		--grep $(GREP) \
+		--grep "$(GREP)" \
 		$(TESTS)
 
 #

--- a/package.json
+++ b/package.json
@@ -15,14 +15,14 @@
     "debug": "~0.7.4",
     "methods": "0.0.1",
     "ms": "~0.6.2",
-    "superagent": "^0.21.0",
+    "superagent": "^2.2.0",
     "to-no-case": "^0.1.2",
     "type": "git://github.com/segmentio/type",
     "uniq-component": "^1.0.0"
   },
   "devDependencies": {
     "jscs": "^1.11.3",
-    "mocha": "~1.17.1",
+    "mocha": "^3.0.2",
     "redis": "^0.12.1",
     "segmentio-facade": "2.x"
   },

--- a/test/proto.js
+++ b/test/proto.js
@@ -218,18 +218,16 @@ describe('proto', function(){
 
     it('should set the user-agent', function(){
       var req = segment.request('post');
-      var header = req.req._headers;
-      assert.equal('Segment.io/1.0', header['user-agent']);
+      assert.equal(req.header['User-Agent'], 'Segment.io/1.0');
       req.abort();
       req.end(function(){});
     });
 
     it('should be able to override the default user agent', function(){
       var req = segment.request('post');
-      var header = req.req._headers;
-      assert.equal('Segment.io/1.0', header['user-agent']);
+      assert.equal(req.header['User-Agent'], 'Segment.io/1.0');
       req.set('User-Agent', 'some-agent');
-      assert.equal('some-agent', header['user-agent']);
+      assert.equal(req.header['User-Agent'], 'some-agent');
       req.abort();
       req.end(function(){});
     });


### PR DESCRIPTION
Related issue: https://github.com/visionmedia/superagent/issues/509

There are many changes in superagent between 0.2.2 and 2.x, so we should issue this as a major version bump to be safe.