### PR TITLE
Add Redis Docker container as development dependency

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,8 +1,12 @@
 machine:
+  services:
+    - docker
   node:
     version: 0.10.46
-  services:
-    - redis
+
+dependencies:
+  pre:
+    - docker-compose up -d
 
 test:
   override:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,4 @@
+redis:
+  image: redis:2.8
+  ports:
+    - "6379:6379"


### PR DESCRIPTION
Tests rely on having a running Redis instance available, but that hasn't
been explicit up until now. Add it via docker-compose to make the
dependency clear and make development easier.