### PR TITLE
use default http agents

### DIFF
--- a/lib/proto.js
+++ b/lib/proto.js
@@ -13,6 +13,8 @@ var includes = require('lodash/includes');
 var methods = require('methods');
 var Batch = require('batch');
 var type = require('type');
+var http = require('http');
+var https = require('https');
 
 /**
  * Retry checks.
@@ -229,8 +231,15 @@ exports.request = function(method, path){
   var end = req.end;
 
   if (this.ca) req.ca(this.ca);
-  if (this.agent) req.agent(this.agent);
   if (this.timeout) req.timeout(this.timeout);
+
+  if (this.agent) {
+    req.agent(this.agent);
+  } else if (url.indexOf('http:') === 0) {
+    req.agent(http.globalAgent)
+  } else if (url.indexOf('https:') === 0) {
+    req.agent(https.globalAgent)
+  }
 
   req.on('response', this.onresponse.bind(this));
   req.set('User-Agent', 'Segment.io/1.0');


### PR DESCRIPTION
@segmentio/infra 
@f2prateek 
@jgershen 

Hey guys, we're seeing connections aborted issues on bigger hosts that have a lot of traffic and believe it's due to ephemeral port exhaustion on the host at high request rates because we don't do any connection pooling on integrations, basically opening a new TCP connections for every request.

This is an attempt to fix it by using the default agent for http or https requests.

I've got guidance from Amir but I'm not very familiar with this repo so I'll be grateful if someone can double check the logic carefully here.

Cheers!
