### PR TITLE
Allow empty array as a valid setting. Remove npm@2 requirement

### DIFF
--- a/lib/proto.js
+++ b/lib/proto.js
@@ -9,10 +9,10 @@ var normalize = require('to-no-case');
 var request = require('superagent');
 var retries = require('./retries');
 var fmt = require('util').format;
+var includes = require('lodash/includes');
 var methods = require('methods');
 var Batch = require('batch');
 var type = require('type');
-var includes = require('@ndhoule/includes');
 
 /**
  * Retry checks.
@@ -115,10 +115,10 @@ exports.enabled = function(facade){
   // Pass through event for unbundled analytics.js integration if
   // - this event came from the browser
   // - this integration is explicitly unbundled in analytics.js
-  if (facade.channel() === 'client' && includes(this.name, facade.proxy('_metadata.unbundled'))) {
+  if (facade.channel() === 'client' && includes(facade.proxy('_metadata.unbundled'), this.name)) {
     return true
   }
-  return includes(facade.channel(), this.channels);
+  return includes(this.channels, facade.channel());
 };
 
 /**

--- a/lib/statics.js
+++ b/lib/statics.js
@@ -299,7 +299,7 @@ function validation(meta){
     // settings
     if ('settings' == type) {
       var value = settings[path];
-      if (null != value && '' != value) return;
+      if (null !== value && undefined !== value && '' !== value) return;
       return this.invalid('setting "%s" is required', path);
     }
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Segment.io integration base prototype",
   "main": "lib/integration.js",
   "keywords": [],
-  "author": "Segment.io <friends@segment.io>",
+  "author": "Segment <friends@segment.com>",
   "scripts": {
     "test": "make test"
   },
@@ -12,17 +12,16 @@
     "type": "git",
     "url": "git://github.com/segmentio/integration.git"
   },
-  "author": "Segment <friends@segment.com>",
   "license": "SEE LICENSE IN LICENSE",
   "bugs": {
     "url": "https://github.com/segmentio/integration/issues"
   },
   "homepage": "https://github.com/segmentio/integration#readme",
   "dependencies": {
-    "@ndhoule/includes": "^2.0.1",
     "analytics-events": "^2.0.2",
     "batch": "^0.5.1",
     "debug": "~0.7.4",
+    "lodash": "^4.16.0",
     "methods": "0.0.1",
     "ms": "~0.6.2",
     "superagent": "^2.2.0",


### PR DESCRIPTION
Empty array loosely equals empty string. This switches it to a strict equality check so empty array is still allowed.

This also removes the dependency on `@ndhoule/includes` since scoped packages aren't supported in `npm@1.x` which is the default npm version for `node@0.10.x` which integrations run on.