### PR TITLE
Add optional timeout to lock

### DIFF
--- a/lib/proto.js
+++ b/lib/proto.js
@@ -183,10 +183,14 @@ exports.map = function(events, str){
  * @api public
  */
 
-exports.lock = function(key, fn){
+exports.lock = function(key, timeout, fn){
+  if (fn === undefined) {
+    fn = timeout;
+    timeout = 15000;
+  }
   var name = this.name;
   var key = [name, key].join(':');
-  this.redis().set(key, 1, 'NX', 'PX', 15000, function(err, ok){
+  this.redis().set(key, 1, 'NX', 'PX', timeout, function(err, ok){
     if (err) return fn(err);
     if (!ok) return fn(new ResourceLockedError(fmt('key `%s` is locked', key), name));
     return fn();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "segmentio-integration",
-  "version": "5.0.1",
+  "version": "5.1.0",
   "description": "Segment.io integration base prototype",
   "main": "lib/integration.js",
   "keywords": [],


### PR DESCRIPTION
This will allow integrations to optionally specify how long to lock for (specifically for the case where they have no intention of unlocking).

This will allow us to convert marketo to a uniform locking method, and handle failed locks with a backoff retry, instead of hard failing the message after a few futile (internal) attempts.