### PR TITLE
Disable gzip encoding on responses

### DIFF
--- a/lib/proto.js
+++ b/lib/proto.js
@@ -247,6 +247,13 @@ exports.request = function(method, path){
 
   req.on('response', this.onresponse.bind(this));
   req.set('User-Agent', 'Segment.io/1.0');
+  // Superagent sets Accept-Encoding: gzip, deflate by default. We don't want
+  // any encoding, since compressing TLS responses with gzip makes them
+  // vulnerable to the CRIME attack.
+  //
+  // There may also be a problem with the Node zlib library using a ton of
+  // memory to decompress messages.
+  req.set('Accept-Encoding', 'identity');
   req.redirects(0);
   req.end = onend;
 

--- a/test/proto.js
+++ b/test/proto.js
@@ -223,6 +223,13 @@ describe('proto', function(){
       req.end(function(){});
     });
 
+    it('should set the Accept-Encoding header', function(){
+      var req = segment.request('post');
+      assert.equal(req.header['Accept-Encoding'], 'identity');
+      req.abort();
+      req.end(function(){});
+    });
+
     it('should be able to override the default user agent', function(){
       var req = segment.request('post');
       assert.equal(req.header['User-Agent'], 'Segment.io/1.0');


### PR DESCRIPTION
Gzipped responses are vulnerable to the CRIME and BEAST attacks which could
allow an attacker to partially read a response.

There also may be an issue with zlib allocating memory to unzip responses and
then not returning it to the heap; this could fix the memory problems we've
been seeing on the Autopilot integration.