### PR TITLE
Add support for using mapper with specd events

### DIFF
--- a/lib/wrap-methods.js
+++ b/lib/wrap-methods.js
@@ -42,18 +42,32 @@ module.exports = function(integration){
     };
   });
 
-  // route ecommerce
+  // Check for and use spec'd events.
   var track = integration.track;
-  integration.track = track && function(msg){
+  integration.track = function(msg, callback){
     var event = msg.event();
+    var fn;
+    var method;
 
-    for (var method in events) {
+    for (method in events) {
       var regexp = events[method];
-      var fn = this[method];
+      fn = this[method]
       if (!fn || !regexp.test(event)) continue;
-      return fn.apply(this, arguments);
+      break;
     }
 
-    return track.apply(this, arguments);
-  };
+    // If we have exited the loop with fn undefined, default back to track and return.
+    if (!fn) {
+      return track.call(this, msg, callback)
+    }
+
+    if (mapper[method]) {
+      var payload = mapper[method].call(this, msg, this.settings);
+      this.debug('mapped %j to %j', msg, payload);
+      return fn.call(this, payload, callback);
+    }
+
+    return fn.call(this, msg, callback)
+  }
+
 };

--- a/test/proto.js
+++ b/test/proto.js
@@ -320,6 +320,13 @@ describe('proto', function(){
       test({}).track(msg, done);
     });
 
+    it('should map a spec\'d event if mapper[specdEvent] is defined', function(done){
+      var test = integration('test').mapper({ orderCompleted: mapper() });
+      test.prototype.orderCompleted = mapper.test(done);
+      var msg = helpers.track({ event: 'Order Completed' });
+      test({}).track(msg, done);
+    });
+
     it('should call .productViewed when the event is /viewed[ _]?product/i', function(){
       var track = helpers.track;
       segment.productViewed = spy();


### PR DESCRIPTION
This PR adds support for using `.mapper` with spec'd events. Previously, all spec'd events needed to have their mapping logic housed in the `track` mapper. This now allows developers to export them individually from the `mapper.js` file. 

This also makes it possible to use specd events without needing to define `track`. Previously, if `track` was undefined but you had specd events define, the message would get dropped.

This is fully backwards compatible.