### PR TITLE
Fix application of facade to batch events

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,8 @@
+7.0.0 / 2020-03-31
+==================
+
+  * Support usage of the facade in server-side batch integrations
+
 6.0.0 / 2019-06-09
 ==================
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@segment/integration",
-  "version": "6.1.0",
+  "version": "7.0.0",
   "description": "Segment.io integration base prototype",
   "main": "./src",
   "keywords": [],

--- a/src/wrap-methods.js
+++ b/src/wrap-methods.js
@@ -62,7 +62,7 @@ module.exports = function (integration) {
           if (mapper[method]) {
             return mapper[method].call(this, ev, this.settings)
           } else {
-            return ev.obj
+            return ev
           }
         })
 


### PR DESCRIPTION
Currently, for events invoked through a batch integration, we return the nested event object, which basically removes the facade. This change fixes that code so the facade is properly sent to batch integration methods.