### PR TITLE
support async hooks

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,8 @@
+7.1.0 / 2020-03-31
+==================
+
+  * Make integration requests compatible with async_hooks by creating an AsyncResource for each request
+
 7.0.0 / 2020-03-31
 ==================
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@segment/integration",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "Segment.io integration base prototype",
   "main": "./src",
   "keywords": [],

--- a/src/proto.js
+++ b/src/proto.js
@@ -3,6 +3,7 @@
  * Module dependencies.
  */
 
+const { AsyncResource } = require('async_hooks')
 var ResourceLockedError = require('./errors').ResourceLockedError
 var ValidationError = require('./errors').Validation
 var normalize = require('to-no-case')

--- a/src/proto.js
+++ b/src/proto.js
@@ -242,6 +242,24 @@ exports.request = function (method, path) {
     return fn(err, res)
   }
 
+  // Captures the current async context by creating an async resource for the
+  // superagent request.
+  //
+  // This is necessary because async_hooks does not follow "Thenable" types,
+  // depsite promises being compatible with them. The "then" method is invoked
+  // asynchronously on a "nextTick", where the async context that originally
+  // created the "Thenable" object has been lost.
+  //
+  // By creating the async resource here and overriding the "then" method, we
+  // bind the request object to the async execution context, and can restore
+  // it via a call to runInAsyncScope in the overriden "then" function.
+  const asyncResource = new AsyncResource('com.segment.integration.Request')
+  const thenFunction = Reflect.get(req, 'then')
+  const thenAsyncHook = function then (resolve, reject) {
+    return asyncResource.runInAsyncScope(thenFunction, this, resolve, reject)
+  }
+
+  req.then = thenAsyncHook
   return req
 }
 


### PR DESCRIPTION
In places where we use `async_hooks`, the propagation of the async execution context stops when async functions returning _thenable_ objects are called. This is because the async function will chain the call to the _thenable_, but it happens asynchronously on the process' next tick, which is outside the scope of the async execution context that originally called the function.

The superagent request objects we use in integrations are _thenable_, which exposes them to this issue. This means that we cannot use async local storage to propagate values from the incoming to outgoing requests.

Full details on the topic can be found in https://github.com/nodejs/node/issues/22360

This PR addresses the issue by explicitly creating an async resource for each request that the integration creates, capturing the current execution context, and restoring it when the `then` method is eventually called.