### PR TITLE
Support feature flags

### DIFF
--- a/History.md
+++ b/History.md
@@ -2,7 +2,7 @@
 ==================
 
   * Support feature flags in event handlers and validation functions. The `Integration` initializer now accepts an array of strings as its second parameter, named `features`.
-    Each item in the array represents **enabled** feature flag for the message in context. For ease of use, the array is converted into an object and can be accessed
+    Each item in the array represents an **enabled** feature flag for the message in context. For ease of use, the array is converted into an object and can be accessed
     like so during validation and event handling:
     ```
       // Validation

--- a/History.md
+++ b/History.md
@@ -1,3 +1,30 @@
+7.2.0 / 2020-09-01
+==================
+
+  * Support feature flags in event handlers and validation functions. The `Integration` initializer now accepts an array of strings as its second parameter, named `features`.
+    Each item in the array represents **enabled** feature flag for the message in context. For ease of use, the array is converted into an object and can be accessed
+    like so during validation and event handling:
+    ```
+      // Validation
+      const Webhooks = Integration('Webhooks)
+        .ensure(function (message, settings, features) {
+          if (features.validate_xyz) {
+            // Validate setting
+          }
+        })
+
+      // Event handlers
+      Webhooks.prototype.track = async function (message) {
+          if (this.features.attempt_header) {
+              req.set('X-Segment-Attempts', '101')
+          }
+      }
+
+      // Passing features
+      const features = ['validate_xyz', 'attempt_header']
+      const instance = new Webhooks(settings, features)
+    ```
+
 7.1.0 / 2020-03-31
 ==================
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@segment/integration",
-  "version": "7.1.0",
+  "version": "7.2.0",
   "description": "Segment.io integration base prototype",
   "main": "./src",
   "keywords": [],

--- a/src/integration.d.ts
+++ b/src/integration.d.ts
@@ -13,7 +13,7 @@ export interface IntegrationStatic<Settings extends object, Options extends obje
    * Creates a new integration.
    * @param settings The integration settings
    */
-  new (settings: Settings, features: string[]): Integration<Settings, Options>
+  new (settings: Settings, features?: string[]): Integration<Settings, Options>
 
   /**
    * Ensure the event contains a specific property value.

--- a/src/integration.d.ts
+++ b/src/integration.d.ts
@@ -93,7 +93,7 @@ export interface IntegrationStatic<Settings extends object, Options extends obje
 export interface Integration<Settings extends object, Options extends object> {
   name: string
   settings: Settings
-  features: string[]
+  features: Record<string, string>
 
   /**
    * Initialize is called when the integration class is instantiated.

--- a/src/integration.d.ts
+++ b/src/integration.d.ts
@@ -13,7 +13,7 @@ export interface IntegrationStatic<Settings extends object, Options extends obje
    * Creates a new integration.
    * @param settings The integration settings
    */
-  new (settings: Settings): Integration<Settings, Options>
+  new (settings: Settings, features: string[]): Integration<Settings, Options>
 
   /**
    * Ensure the event contains a specific property value.
@@ -93,6 +93,7 @@ export interface IntegrationStatic<Settings extends object, Options extends obje
 export interface Integration<Settings extends object, Options extends object> {
   name: string
   settings: Settings
+  features: string[]
 
   /**
    * Initialize is called when the integration class is instantiated.

--- a/src/integration.js
+++ b/src/integration.js
@@ -44,7 +44,11 @@ function createIntegration (name) {
     if (!(this instanceof Integration)) return new Integration(settings, features)
     this.debug = debug('segmentio:integration:' + this.slug())
     this.settings = settings || {}
-    this.features = features || []
+    // Index the features for friendlier reads (e.g.; this.features.my_flag)
+    this.features = (features || []).reduce((map, flag) =>  {
+      map[flag] = true
+      return map
+    }, {})
     Emitter.call(this)
     this.initialize()
     wrapMethods(this)

--- a/src/integration.js
+++ b/src/integration.js
@@ -40,10 +40,11 @@ function createIntegration (name) {
    * @api public
    */
 
-  function Integration (settings) {
-    if (!(this instanceof Integration)) return new Integration(settings)
+  function Integration (settings, features) {
+    if (!(this instanceof Integration)) return new Integration(settings, features)
     this.debug = debug('segmentio:integration:' + this.slug())
     this.settings = settings || {}
+    this.features = features || []
     Emitter.call(this)
     this.initialize()
     wrapMethods(this)

--- a/src/integration.js
+++ b/src/integration.js
@@ -40,7 +40,7 @@ function createIntegration (name) {
    * @api public
    */
 
-  function Integration (settings, features) {
+  function Integration (settings, features = []) {
     if (!(this instanceof Integration)) return new Integration(settings, features)
     this.debug = debug('segmentio:integration:' + this.slug())
     this.settings = settings || {}

--- a/src/proto.js
+++ b/src/proto.js
@@ -378,6 +378,19 @@ exports.retry = function (err) {
 }
 
 /**
+ * Determine if a feature flag is enabled in the set of features
+ * for this integration.
+ *
+ * @param {String} name Name of the feature flag
+ * @return {Boolean}
+ * @api public
+ */
+
+exports.featureOn = function (name) {
+  return this.features.includes(name)
+}
+
+/**
  * Add methods
  */
 

--- a/src/proto.js
+++ b/src/proto.js
@@ -378,19 +378,6 @@ exports.retry = function (err) {
 }
 
 /**
- * Determine if a feature flag is enabled in the set of features
- * for this integration.
- *
- * @param {String} name Name of the feature flag
- * @return {Boolean}
- * @api public
- */
-
-exports.featureOn = function (name) {
-  return this.features.includes(name)
-}
-
-/**
  * Add methods
  */
 

--- a/src/statics.js
+++ b/src/statics.js
@@ -122,12 +122,12 @@ exports.ensure = function (path, meta) {
  * @api public
  */
 
-exports.validate = function (msg, settings) {
+exports.validate = function (msg, settings, features) {
   var all = Object.keys(this.validations)
 
   for (var i = 0, err, fn; i < all.length; ++i) {
     fn = this.validations[i].validate
-    err = fn.call(this, msg, settings)
+    err = fn.call(this, msg, settings, features)
     if (err) return err
   }
 }

--- a/test/validation.js
+++ b/test/validation.js
@@ -93,13 +93,13 @@ describe('validations', function () {
     })
   })
 
-  describe('fn(msg, settings)', function () {
+  describe('fn(msg, settings, features)', function () {
     var args
     var ctx
 
     beforeEach(function () {
       args = []
-      Segment.ensure(function (msg, settings) {
+      Segment.ensure(function (msg, settings, features) {
         ctx = this
         args.push(arguments)
       })
@@ -108,9 +108,11 @@ describe('validations', function () {
     it('should call fn with msg, settings', function () {
       var msg = new Track({})
       var settings = {}
-      Segment.validate(msg, settings)
+      var features = ['new_setting']
+      Segment.validate(msg, settings, features)
       assert.equal(args[0][0], msg)
       assert.equal(args[0][1], settings)
+      assert.equal(args[0][2], features)
     })
 
     it('should call fn with Integration context', function () {

--- a/test/validation.js
+++ b/test/validation.js
@@ -108,7 +108,7 @@ describe('validations', function () {
     it('should call fn with msg, settings', function () {
       var msg = new Track({})
       var settings = {}
-      var features = ['new_setting']
+      var features = { new_setting: true }
       Segment.validate(msg, settings, features)
       assert.equal(args[0][0], msg)
       assert.equal(args[0][1], settings)


### PR DESCRIPTION
Support feature flags in event handlers and validation functions. The `Integration` initializer now accepts an array of strings as its second parameter, named `features`. Each item in the array represents an **enabled** feature flag for the message in context. For ease of use, the array is converted into an object and can be accessed like so during validation and event handling:
```
      // Validation
      const Webhooks = Integration('Webhooks)
        .ensure(function (message, settings, features) {
          if (features.validate_xyz) {
            // Validate setting
          }
        })

      // Event handlers
      Webhooks.prototype.track = async function (message) {
          if (this.features.attempt_header) {
              req.set('X-Segment-Attempts', '101')
          }
      }

      // Passing features
      const features = ['validate_xyz', 'attempt_header']
      const instance = new Webhooks(settings, features)
```

Related:
- `integrations` - https://github.com/segmentio/integrations/pull/1632
- `integrations-engine` - https://github.com/segmentio/integrations-engine/pull/27